### PR TITLE
Add mouse spring interaction and some cross compilation code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 *.exe
 obj/
+.cache/
+
+compile_commands.json
+run.sh

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ ifeq ($(OS),Windows_NT)
 else
 	RM = rm -vf
 	INCLUDE = $(INC_LINUX)
-	CXX_EXTRA_FLAGS = -lglut -lGLU -lGL -lpng
+	#CXX_EXTRA_FLAGS = -lglut -lGLU -lGL -lpng
+	CXX_EXTRA_FLAGS = -framework GLUT -framework OpenGL -lpng
 endif
 
 CXXFLAGS = -g -O2 -Wall -Wno-sign-compare -I$(INCLUDE) -I$(INC_COMMON) -DHAVE_CONFIG_H 

--- a/src/CircularWireConstraint.cpp
+++ b/src/CircularWireConstraint.cpp
@@ -1,5 +1,9 @@
 #include "CircularWireConstraint.h"
+#ifdef __APPLE__
+#include <GLUT/glut.h>
+#else
 #include <GL/glut.h>
+#endif
 #include <math.h>
 
 #define PI 3.1415926535897932384626433832795

--- a/src/Particle.cpp
+++ b/src/Particle.cpp
@@ -1,5 +1,9 @@
 #include "Particle.h"
+#ifdef __APPLE__
+#include <GLUT/glut.h>
+#else
 #include <GL/glut.h>
+#endif
 
 Particle::Particle(const Vec2f & ConstructPos, unsigned int index) :
 	m_ConstructPos(ConstructPos), m_Position(Vec2f(0.0, 0.0)), m_Velocity(Vec2f(0.0, 0.0)), m_Force(Vec2f(0.0, 0.0)), f_Mass(1.0f), index(index)

--- a/src/ParticleToy.cpp
+++ b/src/ParticleToy.cpp
@@ -44,7 +44,7 @@ static Matrix Jt(0, 0);     //jacobian transpose
 static Matrix J_prim(0, 0); //jacobian'
 
 static Particle* selected_particle = nullptr; // Pointer to the selected particle
-static Particle mouseParticle(Vec2f(0.0, 0.0)); // Particle for the mouse, gets updated each time the mouse button is clicked
+static Particle mouseParticle(Vec2f(0.0, 0.0), -1); // Particle for the mouse, gets updated each time the mouse button is clicked
 
 // static Particle *pList;
 static std::vector<Particle*> pVector; // Vector of particles
@@ -532,13 +532,8 @@ static void mouse_func ( int button, int state, int x, int y )
 
 		if(selected_particle)
 		{
-			const double rest_length = 0.2; // rest length of the spring
+			constexpr double rest_length = 0.01; // rest length of the spring
 			mouseParticle.m_Position = mousco;
-
-
-			std::cout<< "mouse_func" << mouseParticle.m_Position << std::endl;
-
-			// Create a spring force between the selected particle and the mouse
 			mouseSpringForce = new SpringForce(selected_particle, &mouseParticle, rest_length, 1.0, 1.0);
 			// NOTE: memory leak when creating spring forces each time
 			fVector.push_back(mouseSpringForce);
@@ -569,9 +564,7 @@ static void motion_func ( int x, int y )
 	// If there is a selected particle, update the spring force accordingly
 	if (selected_particle)
 	{
-		// only update the position of the mous particle
 		mouseParticle.m_Position = normalize_mouse_coordinates(mx, my);
-		std::cout<< "motion_func" << mouseParticle.m_Position[0] << "," << mouseParticle.m_Position[1] << std::endl;
 	}
 }
 

--- a/src/ParticleToy.cpp
+++ b/src/ParticleToy.cpp
@@ -17,7 +17,11 @@
 #include <vector>
 #include <stdlib.h>
 #include <stdio.h>
+#ifdef __APPLE__
+#include <GLUT/glut.h>
+#else
 #include <GL/glut.h>
+#endif
 
 /* macros */
 
@@ -479,6 +483,22 @@ static void key_func ( unsigned char key, int x, int y )
 	}
 }
 
+Vec2f normalize_mouse_coordinates(int x, int y)
+{
+	float edges = 1.0;
+    auto nx = std::min(std::max(x, 0), 512);
+    auto ny = std::min(std::max(y, 0), 512);
+    
+    float normalized_x = (float)nx / 512.0f;
+    float normalized_y = (float)ny / 512.0f;
+    
+    float mapped_x = -edges + normalized_x * (2 * edges);
+    float mapped_y = edges - normalized_y * (2 * edges);
+    
+    return Vec2f(mapped_x, mapped_y);
+}
+
+// This is a GLUT mouse callback that gets triggered when the user presses or releases a mouse button.
 static void mouse_func ( int button, int state, int x, int y )
 {
 	omx = mx = x;
@@ -494,7 +514,7 @@ static void mouse_func ( int button, int state, int x, int y )
 		hmx=x; hmy=y;
 
 		// Find the closest particle to the current mouse position within a certain distance
-		float min_dist = 1.0f;
+		float min_dist = 12491.0f;
 		for (Particle* p : pVector)
 		{
 			float dist = std::sqrt(std::pow(p->m_Position[0] - hmx, 2) + std::pow(p->m_Position[1] - hmy, 2));
@@ -504,13 +524,18 @@ static void mouse_func ( int button, int state, int x, int y )
 				selected_particle = p; // store the selected particle
 			}
 		}
+
 		if(selected_particle)
 		{
+
 			const double rest_length = 0.2; // rest length of the spring
-			mouseParticle.m_Position = Vec2f(hmx, hmy);
+			mouseParticle.m_Position = normalize_mouse_coordinates(hmx, hmy);
+
+
+			std::cout<< "mouse_func" << mouseParticle.m_Position << std::endl;
 
 			// Create a spring force between the selected particle and the mouse
-			static auto mouseSpringForce = new SpringForce(selected_particle, mouseParticle, rest_length, 1.0, 1.0)
+			static auto mouseSpringForce = new SpringForce(selected_particle, &mouseParticle, rest_length, 1.0, 1.0);
 			fVector.push_back(mouseSpringForce);
 			indexSpringForce = fVector.size() - 1;
 		}
@@ -547,7 +572,8 @@ static void motion_func ( int x, int y )
 	if (selected_particle)
 	{
 		// only update the position of the mous particle
-		mouseParticle.m_Position = Vec2f(mx, my);
+		mouseParticle.m_Position = normalize_mouse_coordinates(mx, my);
+		std::cout<< "motion_func" << mouseParticle.m_Position[0] << "," << mouseParticle.m_Position[1] << std::endl;
 	}
 }
 
@@ -756,4 +782,3 @@ int main ( int argc, char ** argv )
 
 	exit ( 0 );
 }
-

--- a/src/ParticleToy.cpp
+++ b/src/ParticleToy.cpp
@@ -498,6 +498,8 @@ Vec2f normalize_mouse_coordinates(int x, int y)
     return Vec2f(mapped_x, mapped_y);
 }
 
+static SpringForce* mouseSpringForce;
+
 // This is a GLUT mouse callback that gets triggered when the user presses or releases a mouse button.
 static void mouse_func ( int button, int state, int x, int y )
 {
@@ -512,40 +514,36 @@ static void mouse_func ( int button, int state, int x, int y )
 	{
 		// Store the current mouse position as the starting point of a drag
 		hmx=x; hmy=y;
+		Vec2f mousco = normalize_mouse_coordinates(x, y);
 
 		// Find the closest particle to the current mouse position within a certain distance
-		float min_dist = 12491.0f;
+		float min_dist = 102401240124.0f;
 		for (Particle* p : pVector)
 		{
-			float dist = std::sqrt(std::pow(p->m_Position[0] - hmx, 2) + std::pow(p->m_Position[1] - hmy, 2));
+			float dist = norm2(p->m_Position - Vec2f(mousco));
 			if (dist < min_dist)
 			{
+
 				min_dist = dist; // update the minimum distance
 				selected_particle = p; // store the selected particle
 			}
+
 		}
 
 		if(selected_particle)
 		{
-
 			const double rest_length = 0.2; // rest length of the spring
-			mouseParticle.m_Position = normalize_mouse_coordinates(hmx, hmy);
+			mouseParticle.m_Position = mousco;
 
 
 			std::cout<< "mouse_func" << mouseParticle.m_Position << std::endl;
 
 			// Create a spring force between the selected particle and the mouse
-			static auto mouseSpringForce = new SpringForce(selected_particle, &mouseParticle, rest_length, 1.0, 1.0);
+			mouseSpringForce = new SpringForce(selected_particle, &mouseParticle, rest_length, 1.0, 1.0);
+			// NOTE: memory leak when creating spring forces each time
 			fVector.push_back(mouseSpringForce);
 			indexSpringForce = fVector.size() - 1;
 		}
-	}
-
-	// If the left mouse button was previously pressed and if it is now released, update that it was released
-	if(mouse_down[button])
-	{
-		mouse_release[button] = (state == GLUT_UP);
-		selected_particle = nullptr; // update the selected_particle, empty it!
 	}
 
 	// If the button was previously pressed and if it is now released, update that it was released

--- a/src/RodConstraint.cpp
+++ b/src/RodConstraint.cpp
@@ -1,5 +1,9 @@
 #include "RodConstraint.h"
+#ifdef __APPLE__
+#include <GLUT/glut.h>
+#else
 #include <GL/glut.h>
+#endif
 #include <math.h>
 
 RodConstraint::RodConstraint(Particle *p1, Particle * p2, double dist, unsigned int index) :

--- a/src/SpringForce.cpp
+++ b/src/SpringForce.cpp
@@ -1,6 +1,11 @@
 #include "SpringForce.h"
+#ifdef __APPLE__
+#include <GLUT/glut.h>
+#else
 #include <GL/glut.h>
+#endif
 
+<<<<<<< HEAD
 SpringForce::SpringForce(Particle *p1, Particle * p2, double dist, double ks, double kd) :
   m_p1(p1), m_p2(p2), m_dist(dist), m_ks(ks), m_kd(kd) {}
 
@@ -16,6 +21,18 @@ void SpringForce::apply_force()
 
     m_p1->m_Force += force;
     m_p2->m_Force += -force;
+=======
+SpringForce::SpringForce(Particle *p1, Particle * p2, double rest_length, double ks, double kd) :
+  m_p1(p1), m_p2(p2), m_dist(rest_length), m_ks(ks), m_kd(kd) {}
+
+void SpringForce::apply_force()
+{
+  Vec2f l = m_p1->m_Position - m_p2->m_Position;
+  Vec2f l_deriv = m_p1->m_Velocity - m_p2->m_Velocity;
+  float magnitude_l = std::sqrt(l[0] * l[0] + l[1] * l[1]);
+  m_p1->m_Force += -(m_ks * (magnitude_l - m_dist) + m_kd * ((l_deriv * l) / magnitude_l)) * (l / magnitude_l);
+  m_p2->m_Force += - (m_p1->m_Force);
+>>>>>>> add spring force when mouse is clicked
 }
 
 void SpringForce::draw()

--- a/src/SpringForce.cpp
+++ b/src/SpringForce.cpp
@@ -5,7 +5,6 @@
 #include <GL/glut.h>
 #endif
 
-<<<<<<< HEAD
 SpringForce::SpringForce(Particle *p1, Particle * p2, double dist, double ks, double kd) :
   m_p1(p1), m_p2(p2), m_dist(dist), m_ks(ks), m_kd(kd) {}
 
@@ -21,18 +20,6 @@ void SpringForce::apply_force()
 
     m_p1->m_Force += force;
     m_p2->m_Force += -force;
-=======
-SpringForce::SpringForce(Particle *p1, Particle * p2, double rest_length, double ks, double kd) :
-  m_p1(p1), m_p2(p2), m_dist(rest_length), m_ks(ks), m_kd(kd) {}
-
-void SpringForce::apply_force()
-{
-  Vec2f l = m_p1->m_Position - m_p2->m_Position;
-  Vec2f l_deriv = m_p1->m_Velocity - m_p2->m_Velocity;
-  float magnitude_l = std::sqrt(l[0] * l[0] + l[1] * l[1]);
-  m_p1->m_Force += -(m_ks * (magnitude_l - m_dist) + m_kd * ((l_deriv * l) / magnitude_l)) * (l / magnitude_l);
-  m_p2->m_Force += - (m_p1->m_Force);
->>>>>>> add spring force when mouse is clicked
 }
 
 void SpringForce::draw()


### PR DESCRIPTION
The mouse spring works by clicking somewhere in the box. The spring is then automatically drawn between the closest particle and a new particle at the mouse position. For now, some constants are used for spring coefficients, but these can and should be tweaked later to enable the desired effect.

Imports for the GLUT lib are also made cross compilation ready between apple and windows.

This is just about implementing functionality, it is not the most beautiful code but for now this is not a priority.